### PR TITLE
Add "check for physical ring" to copy-X return

### DIFF
--- a/BinaryObjectScanner/Protection/CopyX.cs
+++ b/BinaryObjectScanner/Protection/CopyX.cs
@@ -134,7 +134,7 @@ namespace BinaryObjectScanner.Protection
 
                     // Samples: Redump ID 81628
                     if (Array.TrueForAll(block, b => b == 0))
-                        protections.Add("copy-X");
+                        protections.Add("copy-X [Check disc for physical ring]");
 
                     var matchers = new List<ContentMatchSet>
                     {


### PR DESCRIPTION
I seemingly missed it on one return of copy-X. Caught by noigear on a tivola disc he dumped. It had dummy files but no ring (and thus no copy-X), so the need to check for a physical ring was missed.